### PR TITLE
add rows.raw() for getting array copy of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired by fantastic work done by Chris Brody I did not want to re-invent the w
 Features:
   1. iOS and Android supported via identical JavaScript API.
   2. Android in pure Java and Native modes
-  3. SQL transactions 
+  3. SQL transactions
   4. JavaScript interface via plain callbacks or Promises.
   5. Pre-populated SQLite database import from application sandbox
 
@@ -20,9 +20,9 @@ v2.1.3
 v2.1.2
  1. Android Native SQLite connectivity
  2. Change how React parameters are processed to map a Number to Java Double
- 3. Implent hooks for activity lifecycle and automatic db closing on destroy 
+ 3. Implent hooks for activity lifecycle and automatic db closing on destroy
  4. Fix How To Get Started instructions for Android
- 
+
 v2.1.1 - Fixes issues with XCode path and React Native version compatibility
 
 v2.1 - Android support
@@ -78,18 +78,29 @@ var db = SQLite.openDatabase("test.db", "1.0", "Test Database", 200000, openCB, 
 db.transaction((tx) => {
   tx.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [], (tx, results) => {
       console.log("Query completed");
+      
+      // Get rows with Web SQL Database spec compliance.
+      
       var len = results.rows.length;
       for (let i = 0; i < len; i++) {
         let row = results.rows.item(i);
         console.log(`Employee name: ${row.name}, Dept Name: ${row.deptName}`);
       }
+
+      // Alternatively, you can use the non-standard raw method.
+      
+      /*
+        let rows = results.rows.raw(); // shallow copy of rows Array
+
+        rows.map(row => console.log(`Employee name: ${row.name}, Dept Name: ${row.deptName}`));
+      */
     });
 });
 ```
 
 #How to use (Android):
 
-#### Step 1 - NPM Install 
+#### Step 1 - NPM Install
 
 ```shell
 npm install --save react-native-sqlite-storage

--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -393,6 +393,13 @@ SQLitePluginTransaction.prototype.handleStatementSuccess = function(handler, res
       item: function(i) {
         return rows[i];
       },
+      /**
+       * non-standard Web SQL Database method to expose a copy of raw results
+       * @return {Array}
+       */
+      raw: function() {
+        return rows.slice();
+      },
       length: rows.length
     },
     rowsAffected: response.rowsAffected || 0,
@@ -656,5 +663,3 @@ plugin.sqlitePlugin = {
 };
 
 module.exports = plugin.sqlitePlugin;
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sqlite-storage",
-  "version": "2.1.3",
+  "version": "2.2.3",
   "description": "SQLite3 bindings for React Native (Android & iOS)",
   "main": "sqlite.js",
   "scripts": {


### PR DESCRIPTION
As discussed, resolved #21. Added a new raw() method for results.rows. This returns a shallow copy of the row array to keep things safe. README example and package version updated accordingly.

*Also, wasn't sure of most compliant way to implement a test considering the test directory only has example app code.*