### PR TITLE
Fix React packages list declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ public class MainActivity extends ReactActivity {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-        new SQLitePluginPackage(this))   // register SQLite Plugin here
+        new SQLitePluginPackage(this),   // register SQLite Plugin here
         new MainReactPackage());
     }
 }


### PR DESCRIPTION
A typo in the example prevented the example code to work correctly.