### PR TITLE
decouple storage from activity lifecycle

### DIFF
--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -7,7 +7,6 @@
 
 package io.liteglue;
 
-import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -7,8 +7,8 @@
 
 package io.liteglue;
 
-import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
-public class SQLitePlugin extends ReactContextBaseJavaModule implements Application.ActivityLifecycleCallbacks {
+public class SQLitePlugin extends ReactContextBaseJavaModule {
 
     /**
      * Multiple database runner map (static).
@@ -52,14 +52,12 @@ public class SQLitePlugin extends ReactContextBaseJavaModule implements Applicat
     static SQLiteConnector connector = new SQLiteConnector();
 
     static String LOG_TAG = SQLitePlugin.class.getSimpleName();
-
-    protected Activity activity = null;
     protected ExecutorService threadPool;
+    private Context context;
 
-    public SQLitePlugin(ReactApplicationContext reactContext, Activity activity) {
+    public SQLitePlugin(ReactApplicationContext reactContext) {
         super(reactContext);
-        this.activity = activity;
-        this.activity.getApplication().registerActivityLifecycleCallbacks(this);
+        this.context = reactContext.getApplicationContext();
         this.threadPool = Executors.newCachedThreadPool();
     }
 
@@ -147,54 +145,10 @@ public class SQLitePlugin extends ReactContextBaseJavaModule implements Applicat
         return this.threadPool;
     }
 
-    protected Activity getActivity(){
-        return this.activity;
+    protected Context getContext(){
+        return this.context;
     }
 
-    @Override
-    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-
-    }
-
-    @Override
-    public void onActivityStarted(Activity activity) {
-
-    }
-
-    @Override
-    public void onActivityResumed(Activity activity) {
-
-    }
-
-    @Override
-    public void onActivityPaused(Activity activity) {
-
-    }
-
-    @Override
-    public void onActivityStopped(Activity activity) {
-
-    }
-
-    @Override
-    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-
-    }
-
-    /**
-     * If activity matche linked Activity of this plugin, all open databases are closed.
-     *
-     * @param activity
-     */
-    @Override
-    public void onActivityDestroyed(Activity activity) {
-        Activity myActivity = this.getActivity();
-        if (activity == myActivity){
-            myActivity.getApplication().unregisterActivityLifecycleCallbacks(this);
-            Log.d(LOG_TAG, "linked activity destroyed - closing all open databases");
-            this.closeAllOpenDatabases();
-        }
-    }
     /**
      * Executes the request and returns PluginResult.
      *
@@ -362,14 +316,14 @@ public class SQLitePlugin extends ReactContextBaseJavaModule implements Applicat
             if (assetFilePath != null && assetFilePath.length() > 0) {
                 if (assetFilePath.compareTo("1") == 0) {
                     assetFilePath = "www/" + dbname;
-                    in = this.getActivity().getAssets().open(assetFilePath);
+                    in = this.getContext().getAssets().open(assetFilePath);
                     Log.v("info", "Located pre-populated DB asset in app bundle www subdirectory: " + assetFilePath);
                 } else if (assetFilePath.charAt(0) == '~') {
                     assetFilePath = assetFilePath.startsWith("~/") ? assetFilePath.substring(2) : assetFilePath.substring(1);
-                    in = this.getActivity().getAssets().open(assetFilePath);
+                    in = this.getContext().getAssets().open(assetFilePath);
                     Log.v("info", "Located pre-populated DB asset in app bundle subdirectory: " + assetFilePath);
                 } else {
-                    File filesDir = this.getActivity().getFilesDir();
+                    File filesDir = this.getContext().getFilesDir();
                     assetFilePath = assetFilePath.startsWith("/") ? assetFilePath.substring(1) : assetFilePath;
                     File assetFile = new File(filesDir, assetFilePath);
                     in = new FileInputStream(assetFile);
@@ -383,7 +337,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule implements Applicat
 
             if (dbfile == null) {
                 openFlags = SQLiteOpenFlags.CREATE | SQLiteOpenFlags.READWRITE;
-                dbfile = this.getActivity().getDatabasePath(dbname);
+                dbfile = this.getContext().getDatabasePath(dbname);
 
                 if (!dbfile.exists() && in != null) {
                     Log.v("info", "Copying pre-populated db asset to destination");
@@ -543,10 +497,10 @@ public class SQLitePlugin extends ReactContextBaseJavaModule implements Applicat
      * @return true if successful or false if an exception was encountered
      */
     private boolean deleteDatabaseNow(String dbname) {
-        File dbfile = this.getActivity().getDatabasePath(dbname);
+        File dbfile = this.getContext().getDatabasePath(dbname);
 
         try {
-            return this.getActivity().deleteDatabase(dbfile.getAbsolutePath());
+            return this.getContext().deleteDatabase(dbfile.getAbsolutePath());
         } catch (Exception e) {
             Log.e(LOG_TAG, "couldn't delete database", e);
             return false;

--- a/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
@@ -6,8 +6,6 @@
 package io.liteglue;
 
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -19,19 +17,15 @@ import java.util.Collections;
 import java.util.List;
 
 public class SQLitePluginPackage implements ReactPackage {
-    private Activity activity = null;
 
-    public SQLitePluginPackage(Activity activity){
-        this.activity = activity;
+    public SQLitePluginPackage(){
     }
 
     @Override
     public List<NativeModule> createNativeModules(
                                 ReactApplicationContext reactContext) {
       List<NativeModule> modules = new ArrayList<>();
-
-      modules.add(new SQLitePlugin(reactContext, activity));
-
+      modules.add(new SQLitePlugin(reactContext));
       return modules;
     }
 

--- a/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
@@ -5,6 +5,7 @@
  */
 package io.liteglue;
 
+import android.app.Activity;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -17,6 +18,14 @@ import java.util.Collections;
 import java.util.List;
 
 public class SQLitePluginPackage implements ReactPackage {
+
+    /**
+     * @deprecated Please use version without activity parameter
+     * activity parameter is ignored
+     */
+    public SQLitePluginPackage(Activity activity) {
+        this();
+    }
 
     public SQLitePluginPackage(){
     }

--- a/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
+++ b/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
@@ -8,14 +8,13 @@
 package org.pgsqlite;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.app.Application;
 import android.database.Cursor;
 import android.database.CursorWindow;
 import android.database.sqlite.SQLiteCursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteStatement;
+import android.content.Context;
 import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
@@ -48,7 +47,7 @@ import java.io.OutputStream;
 import java.io.IOException;
 
 
-public class SQLitePlugin extends ReactContextBaseJavaModules {
+public class SQLitePlugin extends ReactContextBaseJavaModule {
 
     private static final String PLUGIN_NAME = "SQLite";
 
@@ -433,8 +432,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModules {
      * @param dbfile The File of the destination db
      * @param assetFileInputStream input file stream for pre-populated db asset
      */
-    private void createFromAssets(String dbName, File dbfile, InputStream assetFileInputStream)
-    {
+    private void createFromAssets(String dbName, File dbfile, InputStream assetFileInputStream) {
         OutputStream out = null;
 
         try {

--- a/src/android/src/main/java/org/pgsqlite/SQLitePluginPackage.java
+++ b/src/android/src/main/java/org/pgsqlite/SQLitePluginPackage.java
@@ -5,8 +5,6 @@
  */
 package org.pgsqlite;
 
-
-
 import android.app.Activity;
 
 import com.facebook.react.ReactPackage;
@@ -21,10 +19,16 @@ import java.util.Collections;
 import java.util.List;
 
 public class SQLitePluginPackage implements ReactPackage {
-    private Activity activity = null;
 
+    /**
+     * @deprecated, use method without activity
+     * activity parameter is ignored
+     */
     public SQLitePluginPackage(Activity activity){
-        this.activity = activity;
+        this();
+    }
+
+    public SQLitePluginPackage() {
     }
 
     @Override
@@ -32,7 +36,7 @@ public class SQLitePluginPackage implements ReactPackage {
                                 ReactApplicationContext reactContext) {
       List<NativeModule> modules = new ArrayList<>();
 
-      modules.add(new SQLitePlugin(reactContext, activity));
+      modules.add(new SQLitePlugin(reactContext));
 
       return modules;
     }


### PR DESCRIPTION
to allow background data processing in particular push notification payload persist scenario we need to have storage package decoupled from activity

DB close is not required on android.
All big applications what exist on the market don't use close function as there is no appropriate place to close DB connection in app lifecycle as you are usually want to have it shared between different activities.

By using Activity callbacks you making your application work unpredictable and prohibit background usage of your package.

We are recently moved JS engine initialization to the application level to be able to process push notifications in background correctly.


You could check stack overflow and any other resources regarding to this call - it not need to be called.  