### PR TITLE
Pick build target

### DIFF
--- a/src/ios/SQLite.xcodeproj/project.pbxproj
+++ b/src/ios/SQLite.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SQLite;
 				SKIP_INSTALL = YES;
@@ -248,6 +249,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SQLite;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
My project builds for 8.0 and I have been getting warnings because this project defaults to `8.1`. After adding the build target everything seems to build and work ok.