### PR TITLE
Fixed empty exception message

### DIFF
--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -500,7 +500,9 @@ SQLitePluginTransaction.prototype.run = function() {
             tx.handleStatementFailure(batchExecutes[index].error, newSQLError(response));
           }
         } catch (err) {
-          console.log("warning - exception while invoking a callback: "+JSON.stringify(err));
+          let errorMsg = JSON.stringify(err);
+          if(errorMsg.length < 3) errorMsg = err.toString();
+          console.log("warning - exception while invoking a callback: " + errorMsg);
         }
 
         if (!didSucceed) {

--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -501,7 +501,7 @@ SQLitePluginTransaction.prototype.run = function() {
           }
         } catch (err) {
           let errorMsg = JSON.stringify(err);
-          if(errorMsg.length < 3) errorMsg = err.toString();
+          if(errorMsg === "{}") errorMsg = err.toString();
           console.log("warning - exception while invoking a callback: " + errorMsg);
         }
 


### PR DESCRIPTION
In the catch-handler of SQLitePluginTransaction.prototype.run the exception argument is printed out to the console with JSON.stringify. Unfortunatly this returns very offen an empty object {}, what makes debugging really hard in case of failures. It is empty for instance if the exception is a TypeError:

> TypeError: success is not a function(…)

which comes as a plain object, not a string and which is a very bad candidate for JSON.stringify for some reason. My pull request tries first to use JSON.stringify, but falls back to the toString()-Method, which is implemented per default in every object and also in scalar types like string, number and so on.

My PR has no compatibility breaks and should be easy to merge.