### PR TITLE
toLowerCase -> toLowerCase(Locale.US)

### DIFF
--- a/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import java.io.File;
 import java.lang.IllegalArgumentException;
 import java.lang.Number;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -495,7 +496,7 @@ class SQLiteAndroidDatabase
         Matcher matcher = FIRST_WORD.matcher(query);
         if (matcher.find()) {
             try {
-                return QueryType.valueOf(matcher.group(1).toLowerCase());
+                return QueryType.valueOf(matcher.group(1).toLowerCase(Locale.US));
             } catch (IllegalArgumentException ignore) {
                 // unknown verb
             }

--- a/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
+++ b/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.lang.IllegalArgumentException;
 import java.lang.Number;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -906,7 +907,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
         Matcher matcher = FIRST_WORD.matcher(query);
         if (matcher.find()) {
             try {
-                return QueryType.valueOf(matcher.group(1).toLowerCase());
+                return QueryType.valueOf(matcher.group(1).toLowerCase(Locale.US));
             } catch (IllegalArgumentException ignore) {
                 // unknown verb
             }


### PR DESCRIPTION
In Turkish locale toLowerCase of I symbol returns two-byte symbol so begin and insert would return QueryType.other which may cause issues with certain versions of SQLite cipher. Now localized version of toLowerCase used instead