### PR TITLE
Bug: statement close semantics corrected

### DIFF
--- a/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
@@ -74,6 +74,10 @@ class SQLiteAndroidDatabase
         this.mydb = SQLiteDatabase.openDatabase(dbfile.getAbsolutePath(), null, openFlags);
     }
 
+    boolean isOpen() {
+        return mydb != null && mydb.isOpen();
+    }
+
     /**
      * Close a database (in the current thread).
      */

--- a/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLiteAndroidDatabase.java
@@ -74,10 +74,6 @@ class SQLiteAndroidDatabase
         this.mydb = SQLiteDatabase.openDatabase(dbfile.getAbsolutePath(), null, openFlags);
     }
 
-    boolean isOpen() {
-        return mydb != null && mydb.isOpen();
-    }
-
     /**
      * Close a database (in the current thread).
      */

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -694,83 +694,86 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
 
             boolean hasRows;
 
-            SQLiteStatement myStatement = mydb.prepareStatement(query);
-
+            SQLiteStatement myStatement = null;
             try {
-                for (int i = 0; i < paramsAsJson.length(); ++i) {
-                    if (paramsAsJson.isNull(i)) {
-                        myStatement.bindNull(i + 1);
-                    } else {
-                        Object p = paramsAsJson.get(i);
-                        if (p instanceof Float || p instanceof Double)
-                            myStatement.bindDouble(i + 1, paramsAsJson.getDouble(i));
-                        else if (p instanceof Number)
-                            myStatement.bindLong(i + 1, paramsAsJson.getLong(i));
-                        else
-                            myStatement.bindTextNativeString(i + 1, paramsAsJson.getString(i));
+                try {
+                    myStatement = mydb.prepareStatement(query);
+                    for (int i = 0; i < paramsAsJson.length(); ++i) {
+                        if (paramsAsJson.isNull(i)) {
+                            myStatement.bindNull(i + 1);
+                        } else {
+                            Object p = paramsAsJson.get(i);
+                            if (p instanceof Float || p instanceof Double)
+                                myStatement.bindDouble(i + 1, paramsAsJson.getDouble(i));
+                            else if (p instanceof Number)
+                                myStatement.bindLong(i + 1, paramsAsJson.getLong(i));
+                            else
+                                myStatement.bindTextNativeString(i + 1, paramsAsJson.getString(i));
+                        }
                     }
+
+                    hasRows = myStatement.step();
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    String errorMessage = ex.getMessage();
+                    Log.v("executeSqlBatch", "SQLitePlugin.executeSql[Batch](): Error=" + errorMessage);
+
+
+                    throw ex;
                 }
 
-                hasRows = myStatement.step();
-            } catch (Exception ex) {
-                ex.printStackTrace();
-                String errorMessage = ex.getMessage();
-                Log.v("executeSqlBatch", "SQLitePlugin.executeSql[Batch](): Error=" + errorMessage);
+                // If query result has rows
+                if (hasRows) {
+                    JSONArray rowsArrayResult = new JSONArray();
+                    String key;
+                    int colCount = myStatement.getColumnCount();
 
-                // cleanup statement and throw the exception:
-                myStatement.dispose();
-                throw ex;
-            }
+                    // Build up JSON result object for each row
+                    do {
+                        JSONObject row = new JSONObject();
+                        try {
+                            for (int i = 0; i < colCount; ++i) {
+                                key = myStatement.getColumnName(i);
 
-            // If query result has rows
-            if (hasRows) {
-                JSONArray rowsArrayResult = new JSONArray();
-                String key;
-                int colCount = myStatement.getColumnCount();
+                                switch (myStatement.getColumnType(i)) {
+                                    case SQLColumnType.NULL:
+                                        row.put(key, JSONObject.NULL);
+                                        break;
 
-                // Build up JSON result object for each row
-                do {
-                    JSONObject row = new JSONObject();
-                    try {
-                        for (int i = 0; i < colCount; ++i) {
-                            key = myStatement.getColumnName(i);
+                                    case SQLColumnType.REAL:
+                                        row.put(key, myStatement.getColumnDouble(i));
+                                        break;
 
-                            switch (myStatement.getColumnType(i)) {
-                                case SQLColumnType.NULL:
-                                    row.put(key, JSONObject.NULL);
-                                    break;
+                                    case SQLColumnType.INTEGER:
+                                        row.put(key, myStatement.getColumnLong(i));
+                                        break;
 
-                                case SQLColumnType.REAL:
-                                    row.put(key, myStatement.getColumnDouble(i));
-                                    break;
+                                    case SQLColumnType.BLOB:
+                                    case SQLColumnType.TEXT:
+                                    default: // (just in case)
+                                        row.put(key, myStatement.getColumnTextNativeString(i));
+                                }
 
-                                case SQLColumnType.INTEGER:
-                                    row.put(key, myStatement.getColumnLong(i));
-                                    break;
-
-                                case SQLColumnType.BLOB:
-                                case SQLColumnType.TEXT:
-                                default: // (just in case)
-                                    row.put(key, myStatement.getColumnTextNativeString(i));
                             }
 
+                            rowsArrayResult.put(row);
+
+                        } catch (JSONException e) {
+                            e.printStackTrace();
                         }
+                    } while (myStatement.step());
 
-                        rowsArrayResult.put(row);
-
+                    try {
+                        rowsResult.put("rows", rowsArrayResult);
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
-                } while (myStatement.step());
-
-                try {
-                    rowsResult.put("rows", rowsArrayResult);
-                } catch (JSONException e) {
-                    e.printStackTrace();
+                }
+            } finally {
+                if (myStatement != null) {
+                    myStatement.dispose();
                 }
             }
-
-            myStatement.dispose();
 
             return rowsResult;
         }

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -505,7 +505,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
             try {
                 r.q.put(query);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                cbc.error("Can't put querry into the queue");
             }
         } else {
             cbc.error("Can't attach to database - it's not open yet");

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -8,7 +8,6 @@
 package io.liteglue;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;
@@ -496,34 +495,20 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
      * @param cbc - JS callback
      */
     private void attachDatabase(String dbName, String dbNameToAttach, String dbAlias, CallbackContext cbc) {
-        SQLiteDatabase currentDb = this.getDatabase(dbName);
-        SQLiteDatabase attachDb = this.getDatabase(dbNameToAttach);
-
-        if (attachDb == null || ! attachDb.isOpen()) {
-            if (cbc != null) cbc.error("Database to attach (" + dbNameToAttach + ") is not open");
-            return;
-        }
-
-        if (currentDb == null || ! currentDb.isOpen()) {
-            if (cbc != null) cbc.error("Database " + dbName + " is not open");
-            return;
-        }
-
-        File dbfile = this.getContext().getDatabasePath(dbNameToAttach);
-        String filePathToAttached = dbfile.getAbsolutePath();
-
-        String stmt = "ATTACH DATABASE '" + filePathToAttached + "' AS " + dbAlias;
-        try {
-            this.executeSqlStatementQuery( currentDb, stmt, new JSONArray(), cbc );
-            // if this previous statement fails, it will throw an exception
-            // otherwise it will never call the success handler because no valid
-            // cursor will be return from rawQuery.
-            // That's why we have to call the success handler here
-            if(cbc != null) cbc.success();
-        }
-        catch(Exception e) {
-            Log.e("attachDatabase", "" + e.getMessage());
-            if(cbc != null) cbc.error("Attach failed");
+        DBRunner r = dbrmap.get(dbNameToAttach);
+        if (r != null) {
+            File dbfile = this.getContext().getDatabasePath(dbNameToAttach);
+            String filePathToAttached = dbfile.getAbsolutePath();
+            String stmt = "ATTACH DATABASE '" + filePathToAttached + "' AS " + dbAlias;
+            // TODO: remove qid it's hardcoded in js to be 1111 always anyway
+            DBQuery query = new DBQuery(new String[]{stmt}, new String[]{"1111"}, new JSONArray[]{new JSONArray()}, cbc);
+            try {
+                r.q.put(query);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        } else {
+            cbc.error("Can't attach to database - it's not open yet");
         }
     }
 
@@ -546,6 +531,16 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                 cbc.error("couldn't delete database");
             }
         }
+    }
+
+    /**
+     * Get a database from the db map.
+     *
+     * @param dbname The name of the database.
+     */
+    private SQLiteAndroidDatabase getDatabase(String dbname) {
+        DBRunner r = dbrmap.get(dbname);
+        return (r == null) ? null :  r.mydb;
     }
 
     /**
@@ -919,6 +914,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
     private enum Action {
         open,
         close,
+        attach,
         delete,
         executeSqlBatch,
         backgroundExecuteSqlBatch,

--- a/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePlugin.java
@@ -534,16 +534,6 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Get a database from the db map.
-     *
-     * @param dbname The name of the database.
-     */
-    private SQLiteAndroidDatabase getDatabase(String dbname) {
-        DBRunner r = dbrmap.get(dbname);
-        return (r == null) ? null :  r.mydb;
-    }
-
-    /**
      * Delete a database.
      *
      * @param dbname   The name of the database file

--- a/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
+++ b/src/android/src/main/java/org/pgsqlite/SQLitePlugin.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.lang.IllegalArgumentException;
@@ -364,6 +365,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
             this.getThreadPool().execute(r);
         }
     }
+
     /**
      * Open a database.
      *
@@ -435,12 +437,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                 cbc.error("can't open database " + ex);
             throw ex;
         } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
-            }
+           closeQuietly(in);
         }
     }
 
@@ -478,12 +475,7 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
         } catch (IOException e) {
             Log.v("createFromAssets", "No pre-populated DB found, error=" + e.getMessage());
         } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ignored) {
-                }
-            }
+            closeQuietly(out);
         }
     }
 
@@ -677,16 +669,16 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
 
                 if (queryType == QueryType.update || queryType == QueryType.delete) {
                     if (android.os.Build.VERSION.SDK_INT >= 11) {
-                        SQLiteStatement myStatement = mydb.compileStatement(query);
-
-                        if (jsonparams != null) {
-                            bindArgsToStatement(myStatement, jsonparams[i]);
-                        }
-
+                        SQLiteStatement myStatement = null;
                         int rowsAffected = -1; // (assuming invalid)
 
                         // Use try & catch just in case android.os.Build.VERSION.SDK_INT >= 11 is lying:
                         try {
+                            myStatement = mydb.compileStatement(query);
+                            if (jsonparams != null) {
+                                bindArgsToStatement(myStatement, jsonparams[i]);
+                            }
+
                             rowsAffected = myStatement.executeUpdateDelete();
                             // Indicate valid results:
                             needRawQuery = false;
@@ -699,6 +691,8 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                         } catch (Exception ex) {
                             // Assuming SDK_INT was lying & method not found:
                             // do nothing here & try again with raw query.
+                        } finally {
+                            closeQuietly(myStatement);
                         }
 
                         if (rowsAffected != -1) {
@@ -738,6 +732,8 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                         ex.printStackTrace();
                         errorMessage = ex.getMessage();
                         Log.v("executeSqlBatch", "SQLiteDatabase.executeInsert(): Error=" + errorMessage);
+                    } finally {
+                       closeQuietly(myStatement);
                     }
                 }
 
@@ -867,8 +863,9 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
             Matcher tableMatcher = UPDATE_TABLE_NAME.matcher(query);
             if (tableMatcher.find()) {
                 String table = tableMatcher.group(1);
+                SQLiteStatement statement = null;
                 try {
-                    SQLiteStatement statement = mydb.compileStatement(
+                     statement = mydb.compileStatement(
                             "SELECT count(*) FROM " + table + where);
 
                     if (subParams != null) {
@@ -879,22 +876,26 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                 } catch (Exception e) {
                     // assume we couldn't count for whatever reason, keep going
                     Log.e(SQLitePlugin.class.getSimpleName(), "uncaught", e);
+                } finally {
+                    closeQuietly(statement);
                 }
             }
         } else { // delete
             Matcher tableMatcher = DELETE_TABLE_NAME.matcher(query);
             if (tableMatcher.find()) {
                 String table = tableMatcher.group(1);
+                SQLiteStatement statement = null;
                 try {
-                    SQLiteStatement statement = mydb.compileStatement(
+                     statement = mydb.compileStatement(
                             "SELECT count(*) FROM " + table + where);
                     bindArgsToStatement(statement, subParams);
 
                     return (int)statement.simpleQueryForLong();
                 } catch (Exception e) {
                     // assume we couldn't count for whatever reason, keep going
-                    Log.e(SQLitePlugin.class.getSimpleName(), "uncaught", e);
-
+                    Log.e(LOG_TAG, "uncaught", e);
+                } finally {
+                    closeQuietly(statement);
                 }
             }
         }
@@ -943,69 +944,70 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
                                                 CallbackContext cbc) throws Exception {
         JSONObject rowsResult = new JSONObject();
 
-        Cursor cur;
+        Cursor cur = null;
         try {
-            String[] params;
+            try {
+                String[] params;
 
-            params = new String[paramsAsJson.length()];
+                params = new String[paramsAsJson.length()];
 
-            for (int j = 0; j < paramsAsJson.length(); j++) {
-                if (paramsAsJson.isNull(j))
-                    params[j] = "";
-                else
-                    params[j] = paramsAsJson.getString(j);
+                for (int j = 0; j < paramsAsJson.length(); j++) {
+                    if (paramsAsJson.isNull(j)) {
+                        params[j] = "";
+                    } else {
+                        params[j] = paramsAsJson.getString(j);
+                    }
+                }
+
+                cur = mydb.rawQuery(query, params);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                String errorMessage = ex.getMessage();
+                Log.v("executeSqlBatch", "SQLitePlugin.executeSql[Batch](): Error=" + errorMessage);
+                throw ex;
             }
 
-            cur = mydb.rawQuery(query, params);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            String errorMessage = ex.getMessage();
-            Log.v("executeSqlBatch", "SQLitePlugin.executeSql[Batch](): Error=" + errorMessage);
-            throw ex;
-        }
+            // If query result has rows
+            if (cur != null && cur.moveToFirst()) {
+                JSONArray rowsArrayResult = new SQLiteArray(cur.getCount());
+                String key;
+                int colCount = cur.getColumnCount();
 
-        // If query result has rows
-        if (cur != null && cur.moveToFirst()) {
-            JSONArray rowsArrayResult = new SQLiteArray(cur.getCount());
-            String key;
-            int colCount = cur.getColumnCount();
+                // Build up JSON result object for each row
+                do {
+                    JSONObject row = new SQLiteObject(colCount);
+                    try {
+                        for (int i = 0; i < colCount; ++i) {
+                            key = cur.getColumnName(i);
 
-            // Build up JSON result object for each row
-            do {
-                JSONObject row = new SQLiteObject(colCount);
-                try {
-                    for (int i = 0; i < colCount; ++i) {
-                        key = cur.getColumnName(i);
+                            if (android.os.Build.VERSION.SDK_INT >= 11) {
 
-                        if (android.os.Build.VERSION.SDK_INT >= 11) {
-
-                            // Use try & catch just in case android.os.Build.VERSION.SDK_INT >= 11 is lying:
-                            try {
-                                bindPostHoneycomb(row, key, cur, i);
-                            } catch (Exception ex) {
+                                // Use try & catch just in case android.os.Build.VERSION.SDK_INT >= 11 is lying:
+                                try {
+                                    bindPostHoneycomb(row, key, cur, i);
+                                } catch (Exception ex) {
+                                    bindPreHoneycomb(row, key, cur, i);
+                                }
+                            } else {
                                 bindPreHoneycomb(row, key, cur, i);
                             }
-                        } else {
-                            bindPreHoneycomb(row, key, cur, i);
                         }
+
+                        rowsArrayResult.put(row);
+
+                    } catch (JSONException e) {
+                        Log.e(LOG_TAG, e.getMessage(), e);
                     }
+                } while (cur.moveToNext());
 
-                    rowsArrayResult.put(row);
-
+                try {
+                    rowsResult.put("rows", rowsArrayResult);
                 } catch (JSONException e) {
-                    e.printStackTrace();
+                   Log.e(LOG_TAG, e.getMessage(), e);
                 }
-            } while (cur.moveToNext());
-
-            try {
-                rowsResult.put("rows", rowsArrayResult);
-            } catch (JSONException e) {
-                e.printStackTrace();
             }
-        }
-
-        if (cur != null) {
-            cur.close();
+        } finally {
+            closeQuietly(cur);
         }
 
         return rowsResult;
@@ -1052,6 +1054,16 @@ public class SQLitePlugin extends ReactContextBaseJavaModule {
             row.put(key, new String(Base64.encode(cursor.getBlob(i), Base64.DEFAULT)));
         } else { // string
             row.put(key, cursor.getString(i));
+        }
+    }
+
+    private void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                // ignore
+            }
         }
     }
 


### PR DESCRIPTION
Sqlite cipher not as forgiving to not closing statements.

As part of this PR I have:
java plugin statement close refactoring

android-native plugin dispose logic cleaned up

native plugin attach logic compiles now
native plugin attach logic thread model fixed: we don't suppose to access DB object outside of DBRunner.

@hhuebel please verify that it still works for you. Try android-native plugin as well.

