### PR TITLE
Fix determination of db opened

### DIFF
--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -234,7 +234,7 @@ SQLitePlugin.prototype.sqlBatch = function(sqlStatements, success, error) {
 SQLitePlugin.prototype.open = function(success, error) {
   var openerrorcb, opensuccesscb;
 
-  if (this.dbname in this.openDBs) {
+  if (this.dbname in this.openDBs && this.openDBs[this.dbname] === DB_STATE_OPEN) {
     console.log('database already open: ' + this.dbname);
     nextTick((function(_this) {
       return function() {


### PR DESCRIPTION
Hi there! I fixed a bug what remains `new transaction is waiting for open operation` after a message which `OPEN database: test.db` is shown at the console.

Perhaps this issue is related with https://github.com/andpor/react-native-sqlite-storage/issues/82.

### environments
On Android device which is v5.0.2.
```
"dependencies": {
  "react": "15.4.2",
  "react-native": "0.42.0",
  "react-native-sqlite-storage": "^3.2.2"
}
```