### PR TITLE
Drop usage of the dead rnpm repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-native": ">=0.14.0"
   },
   "dependencies": {
-    "rnpm": "1.5.2",
     "xcode": "0.8.9"
   },
   "rnpm": {

--- a/scripts/rnpm-postlink.js
+++ b/scripts/rnpm-postlink.js
@@ -2,12 +2,13 @@
 
 'use strict';
 
+require('react-native/setupBabel')();
 var fs = require('fs');
-var rnpm = require('rnpm/src/config');
+var cli = require('react-native/local-cli/core');
 var xcode = require('xcode');
 
 // The current working directory should be project root of the app that is linking react-native-sqlite.
-var config = rnpm.getProjectConfig();
+var config = cli.getProjectConfig();
 
 if (config.ios) {
     var pbxproj = config.ios.pbxprojPath;


### PR DESCRIPTION
`rnpm` has been replaced by `react-native link`, the `rnpm` package is no longer maintained and is out of sync with the code that actually calls postlink.