### PR TITLE
Include Yoga as a dependency in podfile to work with React Native 0.44

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,6 @@
 platform :ios, '8.0'
 target 'AwesomeProject' do
+  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
   pod 'React', :path => '../node_modules/react-native'
   pod 'react-native-sqlite-storage', :path => '../node_modules/react-native-sqlite-storage'
 end


### PR DESCRIPTION
I just got started on React and got the same error reported in #160 

By adding Yoga to the podfile then running `pod install` I was able to run the ios demo as per the instruction.

Looking forwarding to moving forward with this library, thanks a lot.