### PR TITLE
Remove createJSModules @ovveride marker - RN 0.47 compatibility

### DIFF
--- a/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
+++ b/src/android-native/src/main/java/io/liteglue/SQLitePluginPackage.java
@@ -38,7 +38,7 @@ public class SQLitePluginPackage implements ReactPackage {
       return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/src/android/src/main/java/org/pgsqlite/SQLitePluginPackage.java
+++ b/src/android/src/main/java/org/pgsqlite/SQLitePluginPackage.java
@@ -41,7 +41,7 @@ public class SQLitePluginPackage implements ReactPackage {
       return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker.