### PR TITLE
Avoid converting Date objects to strings in addStatement

### DIFF
--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -1,5 +1,5 @@
 /*
- * sqlite.ios.core.js
+ * sqlite.core.js
  *
  * Created by Andrzej Porebski on 10/29/15.
  * Copyright (c) 2015-2016 Andrzej Porebski.
@@ -491,8 +491,11 @@ SQLitePluginTransaction.prototype.addStatement = function(sql, values, success, 
       } else if (t === 'boolean') {
         //Convert true -> 1 / false -> 0
         params.push(~~v);
-      }
-      else if (t !== 'function') {
+      } else if (v instanceof Date) {
+        //A Date is of type 'object', but can be handled directly as is.
+        //Converting to a string like with other objects is not what we want.
+        params.push(v)
+      } else if (t !== 'function') {
         params.push(v.toString());
         console.warn('addStatement - parameter of type <'+t+'> converted to string using toString()')
       } else {


### PR DESCRIPTION
I came across an issue while querying dates using typeORM's query builder. Date objects would be passed to addStatement by typeORM, but as they are considered an object they would be converted by this library to a string. In my case this would result in no matching results being returned, even though they were inserted fine using Date objects in this library (through typeORM).

```
var startMonth = moment().startOf('month').toDate()
var endMonth = moment().endOf('month').toDate()
var hoursQuery = await getRepository(Hours).createQueryBuilder('hour').select()
hoursQuery.where('hour.startTime > :startMonth AND hour.endTime < :endMonth', {startMonth, endMonth})
var hours = await hoursQuery.getMany()
```

I believe the solution is to keep Date objects as is. It's something that's working fine for me on Android, however I cannot confirm the case for iOS due to a lack of resources. I assume it's the same implementation on the native side?