### PR TITLE
Gradle dependency from jcenter is failing, 2.2.0 is too old for google()

### DIFF
--- a/src/android-native/build.gradle
+++ b/src/android-native/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
@@ -29,7 +30,7 @@ android {
     }
     sourceSets.main {
         jni.srcDirs = [] // This prevents the auto generation of Android.mk
-        jniLibs.srcDir 'libs' 
+        jniLibs.srcDir 'libs'
     }
 }
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 


### PR DESCRIPTION
Should resolve #294

I'm experiencing this same issue from some of my other dependencies, and it looks like they're doing more or less the same thing:

https://github.com/react-native-community/react-native-svg/commit/81f483aaf59313303ca7decb4c1a859d29506020
https://github.com/react-native-community/react-native-svg/commit/a82d4876b322f908d13890b90f5c276579cfd545