### PR TITLE
Updating pod tag to match actual tagging scheme and upping android compile sdk

### DIFF
--- a/react-native-sqlite-storage.podspec
+++ b/react-native-sqlite-storage.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/andpor/react-native-sqlite-storage"
   s.license  = package['license']
   s.author   = package['author']
-  s.source   = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.source   = { :git => package['repository']['url'], :tag => "#{s.version}" }
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -16,7 +16,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
     buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {


### PR DESCRIPTION
Fixing the podspec to use the actual tag style (eg `3.x.x` vs `v3.x.x`) so that the podspec can be used with `podspec` directive in Podfiles vs just `path`.