### PR TITLE
Add support for iOS shared container spaces as a DB location

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ where the `location` option may be set to one of the following choices:
 - `default`: `Library/LocalDatabase` subdirectory - *NOT* visible to iTunes and *NOT* backed up by iCloud
 - `Library`: `Library` subdirectory - backed up by iCloud, *NOT* visible to iTunes
 - `Documents`: `Documents` subdirectory - visible to iTunes and backed up by iCloud
+- `Shared`:  app group's shared container - *see next section*
 
 The original webSql style openDatabase still works and the location will implicitly default to 'default' option:
 
@@ -292,6 +293,34 @@ The original webSql style openDatabase still works and the location will implici
 SQLite.openDatabase("myDatabase.db", "1.0", "Demo", -1);
 ```
 
+## Opening a database in an App Group's Shared Container (iOS)
+
+If you have an iOS app extension which needs to share access to the same DB instance as your main app, you must use the shared container of a registered app group.
+
+Assuming you have already set up an app group and turned on the "App Groups" entitlement of both the main app and app extension, setting them to the same app group name, the following extra steps must be taken:
+
+#### Step 1 - supply your app group name in all needed `Info.plist`s
+
+In both `ios/MY_APP_NAME/Info.plist` and `ios/MY_APP_EXT_NAME/Info.plist` (along with any other app extensions you may have), you simply need to add the `AppGroupName` key to the main dictionary with your app group name as the string value:
+
+```xml
+<plist version="1.0">
+<dict>
+  <!-- ... -->
+  <key>AppGroupName</key>
+  <string>MY_APP_GROUP_NAME</string>
+  <!-- ... -->
+</dict>
+</plist>
+```
+
+#### Step 2 - set shared database location
+
+When calling `SQLite.openDatabase` in your React Native code, you need to set the `location` param to `'Shared'`:
+
+```js
+SQLite.openDatabase({name: 'my.db', location: 'Shared'}, successcb, errorcb);
+```
 
 ## Importing a pre-populated database.
 

--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -713,7 +713,8 @@ SQLitePluginTransaction.prototype.abortFromQ = function(sqlerror) {
 dblocations = {
   'default' : 'nosync',
   'Documents' : 'docs',
-  'Library' : 'libs'
+  'Library' : 'libs',
+  'Shared' : 'shared'
 };
 
 SQLiteFactory = function(){};

--- a/platforms/ios/SQLite.m
+++ b/platforms/ios/SQLite.m
@@ -119,6 +119,14 @@ RCT_EXPORT_MODULE();
         [appDBPaths setObject: libs forKey:@"nosync"];
       }
     }
+
+    NSURL* groupURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.worldbrain.memex"];
+    if (groupURL != NULL)
+    {
+       NSString* shared = groupURL.path;
+       RCTLog(@"Detected Shared path: %@", shared);
+       [appDBPaths setObject: shared forKey:@"shared"];
+    }
   }
   return self;
 }

--- a/platforms/ios/SQLite.m
+++ b/platforms/ios/SQLite.m
@@ -120,7 +120,8 @@ RCT_EXPORT_MODULE();
       }
     }
 
-    NSURL* groupURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.worldbrain.memex"];
+    NSString *groupName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroupName"];
+    NSURL *groupURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupName];
     if (groupURL != NULL)
     {
        NSString* shared = groupURL.path;

--- a/platforms/ios/SQLite.m
+++ b/platforms/ios/SQLite.m
@@ -234,6 +234,9 @@ RCT_EXPORT_METHOD(open: (NSDictionary *) options success:(RCTResponseSenderBlock
             }
           }
 #endif
+
+          sqlite3_exec(db, "PRAGMA journal_mode=WAL;", NULL, NULL, NULL);
+
           // Attempt to read the SQLite master table [to support SQLCipher version]:
           if(sqlite3_exec(db, (const char*)"SELECT count(*) FROM sqlite_master;", NULL, NULL, NULL) == SQLITE_OK) {
             NSValue *dbPointer = [NSValue valueWithPointer:db];


### PR DESCRIPTION
Allows me to open a DB instance using iOS shared data containers for a specified app group. A valid app group name must be specified in the app's (and any extensions') `Info.plist` under the `AppGroupName` key.

There's probably some other work to be done, like documenting how to use it and possibly error handling. Please let me know what you think.

- addresses #308 
- all credit goes to @jordoh who put a snippet demonstrating how to do this in the above thread