### PR TITLE
fix: fixed the `source` field

### DIFF
--- a/react-native-sqlite-storage.podspec
+++ b/react-native-sqlite-storage.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/andpor/react-native-sqlite-storage"
   s.license  = package['license']
   s.author   = package['author']
-  s.source   = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.source   = { :git => "https://github.com/andpor/react-native-sqlite-storage.git", :tag => "#{s.version}" }
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
The `source` field was causing errors when attempting to link the library via CocoaPods in iOS. It was unable to resolve the source since the tagging strategy seems to have changed to not include the "v" in the tag name and also, the URL needed to have the "git+" removed from it. I did not want to update the `package.json` file as well, so I just added in the source URL into the podspec directly.