### PR TITLE
change RN to maven google

### DIFF
--- a/platforms/android-native/build.gradle
+++ b/platforms/android-native/build.gradle
@@ -36,9 +36,13 @@ android {
 
 repositories {
     mavenCentral()
+    google()
+    maven {
+        url "https://maven.google.com"
+    }
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:0.14.+'
+    implementation 'com.facebook.react:react-native:+'
     implementation files('libs/sqlite-connector.jar')
 }

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -32,6 +32,10 @@ android {
 
 repositories {
     mavenCentral()
+    google()
+    maven {
+        url "https://maven.google.com"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes https://github.com/andpor/react-native-sqlite-storage/issues/387, will work with RN 0.61 bundled Android `.so` versions.

Change `android-native/build.gradle` to not use specific version `implementation 'com.facebook.react:react-native:+'` and add `maven.google.com` repository to properly fetch RN lib.

