### PR TITLE
sqlBatch - make starting a transaction optional

### DIFF
--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -192,10 +192,15 @@ SQLitePlugin.prototype.abortAllPendingTransactions = function() {
   }
 };
 
-SQLitePlugin.prototype.sqlBatch = function(sqlStatements, success, error) {
-  var batchList, j, len1, myfn, st;
+SQLitePlugin.prototype.sqlBatch = function(sqlStatements, success, error, startTx) {
+  var batchList, j, len1, myfn, st, tx;
   if (!sqlStatements || sqlStatements.constructor !== Array) {
     throw newSQLError('sqlBatch expects an array');
+  }
+  if (startTx === false) {
+    tx = false;
+  } else {
+    tx = true;
   }
   batchList = [];
   for (j = 0, len1 = sqlStatements.length; j < len1; j++) {
@@ -237,7 +242,7 @@ SQLitePlugin.prototype.sqlBatch = function(sqlStatements, success, error) {
     }
   };
 
-  this.addTransaction(new SQLitePluginTransaction(this, myfn, myerror, mysuccess, true, false));
+  this.addTransaction(new SQLitePluginTransaction(this, myfn, myerror, mysuccess, tx, false));
 };
 
 


### PR DESCRIPTION
I've found that using sqlBatch can cause large performance improvements for me, but sometimes I want to do more than 1 batch in a single transaction.  I added an optional parameter so that the default behavior doesn't change and this is backwards compatible.