### PR TITLE
Add prominent instruction for enabling Promises to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Version 3.2 is the first version compatible with RN 0.40.
 ```
 Then follow the instructions for your platform to link react-native-sqlite-storage into your project
 
+## Promises
+To enable promises, run 
+```javascript
+SQLite.enablePromise(true);
+```
+
 ## iOS
 #### Standard Method
 ** React Native 0.60 and above **


### PR DESCRIPTION
As there is no mention of `SQLite.enablePromise(true);` in the Readme, I expected promises to work out of the box. 
After some time verifying that callbacks work but no result is returned from the functions that are supposed to return promises, I was about to file an issue, at which point I found #409 . 

I think adding this to the Readme, prominently at the top, would be a quick solution that prevents this happening to anyone else.