### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/react-native-sqlite-storage.podspec
+++ b/react-native-sqlite-storage.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'LICENSE', 'package.json', 'sqlite.js'
   s.source_files   = "platforms/ios/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.library = 'sqlite3'
 end


### PR DESCRIPTION
Xcode 12 won't build if a module depends on React instead of React-Core. 

More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116