### PR TITLE
Bugfix: define plugin.error and reject any unknow type parameter in addStatement

### DIFF
--- a/lib/sqlite.core.js
+++ b/lib/sqlite.core.js
@@ -56,7 +56,7 @@ let nextTick = setImmediate ||  function(fun) {
 if (global.window) {
   nextTick = window.setImmediate || function(fun) {
     window.setTimeout(fun, 0);
-  };  
+  };
 }
 
 /*
@@ -91,6 +91,12 @@ plugin.exec = function(method, options, success, error) {
 plugin.log = function(...messages) {
   if (plugin.sqlitePlugin.DEBUG) {
     console.log(...messages)
+  }
+}
+
+plugin.error = function(...message) {
+  if (plugin.sqlitePlugin.DEBUG) {
+    console.error(...message);
   }
 }
 
@@ -501,10 +507,6 @@ SQLitePluginTransaction.prototype.addStatement = function(sql, values, success, 
       } else if (t === 'boolean') {
         //Convert true -> 1 / false -> 0
         params.push(~~v);
-      }
-      else if (t !== 'function') {
-        params.push(v.toString());
-        plugin.warn('addStatement - parameter of type <'+t+'> converted to string using toString()')
       } else {
         let errorMsg = 'Unsupported parameter type <'+t+'> found in addStatement()';
         plugin.error(errorMsg);
@@ -598,7 +600,7 @@ SQLitePluginTransaction.prototype.run = function() {
       }
     };
   };
-  
+
   i = 0;
   callbacks = [];
   while (i < batchExecutes.length) {


### PR DESCRIPTION
Currently passing an object or function as parameter causes an unhandled exception, without calling error callbacks or rejecting promise. The reason is that, on such inputs, an undefined function `plugin.error()`/`plugin.warn()` is called.
Reading the code, it was expected to accept anything other than functions, but this PR reject objects as well, because it is more consistent with the current behaviour, and I think such inputs should be regarded as invalid anyway.

PS: my editor automatically removes extra spaces from some irrelevant lines. Sorry about that.