### PR TITLE
Fix autolink for React Native 0.69

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,9 +1,7 @@
 module.exports = {
 	dependency: {
 		platforms: {
-			ios: {
-				project: './platforms/ios/SQLite.xcodeproj'
-			},
+			ios: {},
 			android: {
 				sourceDir: './platforms/android'
 			},


### PR DESCRIPTION
fix #522 

I remove deprecated params from 'react-native.config.js' for React Native 0.69.

Since audolinking automatically assumes that the podspec file is in the root of the package directory, it is no longer necessary to specify the PodspecPath in config.

Source: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md

> On the iOS side, you will need to ensure you have a Podspec to the root of your repo. The react-native-webview Podspec is a good example of a [package.json](https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec)-driven Podspec. Note that CocoaPods does not support having /s in the name of a dependency, so if you are using scoped packages - you may need to change the name for the Podspec.